### PR TITLE
Add support for Django 1.9+

### DIFF
--- a/bananas/compat/__init__.py
+++ b/bananas/compat/__init__.py
@@ -1,0 +1,9 @@
+import django
+
+if django.VERSION[0] == 1 and django.VERSION[1] < 9:
+    from .django18 import ExtendedModelDictQuerySetMixin, ModelDictQuerySetMixin
+else:
+    from .django19 import ExtendedModelDictQuerySetMixin, ModelDictQuerySetMixin
+
+
+__all__ = ['ExtendedModelDictQuerySetMixin', 'ModelDictQuerySetMixin']

--- a/bananas/compat/django18.py
+++ b/bananas/compat/django18.py
@@ -1,0 +1,67 @@
+from django.db.models.query import ValuesQuerySet
+
+from ..utils import ModelDict
+
+
+class ModelDictValuesQuerySet(ValuesQuerySet):
+
+    def iterator(self):
+        return (ModelDict(v) for v in super(ModelDictValuesQuerySet,
+                                            self).iterator())
+
+
+class ModelDictQuerySetMixin:
+
+    def dicts(self, *fields):
+        return self._clone(klass=ModelDictValuesQuerySet, setup=True,
+                           _fields=fields)
+
+
+class ExtendedValuesQuerySet(ValuesQuerySet):
+    """
+    Extended `ValuesQuerySet` with support for renaming fields
+    and choice of object class.
+    """
+    _values_class = dict
+
+    @property
+    def named_fields(self):
+        return getattr(self, '_named_fields')
+
+    def rename_fields(self, names):
+        named_fields = self.named_fields
+        if named_fields:
+            names = [named_fields.get(name, name) for name in names]
+        return names
+
+    def iterator(self):
+        # Purge any extra columns that haven't been explicitly asked for
+        extra_names = list(self.query.extra_select)
+        field_names = self.field_names
+        annotation_names = list(self.query.annotation_select)
+
+        # Modified super(); rename fields given in queryset.values() kwargs
+        names = self.rename_fields(extra_names + field_names + annotation_names)
+
+        for row in self.query.get_compiler(self.db).results_iter():
+            yield self._values_class(zip(names, row))
+
+    def _clone(self, klass=None, setup=False, **kwargs):
+        kwargs.update(_named_fields=self.named_fields,
+                      _values_class=self._values_class,
+                      klass=klass,
+                      setup=setup)
+
+        return super()._clone(**kwargs)
+
+
+class ExtendedModelDictQuerySetMixin:
+
+    def dicts(self, *fields, **named_fields):
+        if named_fields:
+            named_fields = {value: key for key, value in named_fields.items()}
+            fields = fields + tuple(named_fields.keys())
+
+        return self._clone(klass=ExtendedValuesQuerySet, setup=True,
+                           _fields=fields, _named_fields=named_fields,
+                           _values_class=ModelDict)

--- a/bananas/compat/django19.py
+++ b/bananas/compat/django19.py
@@ -1,0 +1,49 @@
+from ..utils import ModelDict
+
+
+def _create_names_and_iterable(queryset):
+    query = queryset.query
+    compiler = query.get_compiler(queryset.db)
+
+    field_names = list(query.values_select)
+    extra_names = list(query.extra_select)
+    annotation_names = list(query.annotation_select)
+
+    # extra(select=...) cols are always at the start of the row.
+    names = extra_names + field_names + annotation_names
+    rows = compiler.results_iter()
+    return names, rows
+
+
+class ModelDictQuerySetMixin:
+
+    def dicts(self, *fields):
+        def _iterable_func(queryset):
+            names, rows = _create_names_and_iterable(queryset)
+            for row in rows:
+                yield ModelDict(zip(names, row))
+
+        clone = self._values(*fields)
+        clone._iterable_class = _iterable_func
+        return clone
+
+
+class ExtendedModelDictQuerySetMixin:
+
+    def dicts(self, *fields, **named_fields):
+        if named_fields:
+            named_fields = {value: key for key, value in named_fields.items()}
+            fields = fields + tuple(named_fields.keys())
+
+        def _iterable_func(queryset):
+            names, rows = _create_names_and_iterable(queryset)
+
+            if named_fields:
+                names = [named_fields.get(name, name) for name in names]
+
+            for row in rows:
+                yield ModelDict(zip(names, row))
+
+        clone = self._values(*fields)
+        clone._iterable_class = _iterable_func
+        return clone

--- a/bananas/query.py
+++ b/bananas/query.py
@@ -1,120 +1,16 @@
 import logging
-from itertools import chain
-from django.db.models.query import QuerySet, ValuesQuerySet
 
-MISSING = object()
+from django.db.models.query import QuerySet
+
+from .compat import ExtendedModelDictQuerySetMixin, ModelDictQuerySetMixin
+from .utils import ModelDict
+
+__all__ = [
+    'ModelDict', 'ModelDictQuerySet', 'ModelDictManagerMixin', 'ExtendedQuerySet'
+]
+
 
 _log = logging.getLogger(__name__)
-
-
-class ModelDict(dict):
-
-    _nested = None
-
-    def __getattr__(self, item):
-        """
-        Try to to get attribute as key item.
-        Fallback on prefixed nested keys.
-        Finally fallback on real attribute lookup.
-        """
-        try:
-            return self.__getitem__(item)
-        except KeyError:
-            try:
-                return self.__getnested__(item)
-            except KeyError:
-                return self.__getattribute__(item)
-
-    def __getnested__(self, item):
-        """
-        Find existing items prefixed with given item
-        and return a new ModelDict containing matched keys,
-        stripped from prefix.
-
-        :param str item: Item prefix key to find
-        :return ModelDict:
-        """
-        # Ensure _nested cache
-        if self._nested is None:
-            self._nested = {}
-
-        # Try to get previously accessed/cached nested item
-        value = self._nested.get(item, MISSING)
-
-        if value is not MISSING:
-            # Return previously accessed nested item
-            return value
-
-        else:
-            # Find any keys matching nested prefix
-            prefix = item + '__'
-            keys = [key for key in self.keys() if key.startswith(prefix)]
-
-            if keys:
-                # Construct nested dict of matched keys, stripped from prefix
-                n = ModelDict({key[len(item)+2:]: self[key] for key in keys})
-
-                # Cache and return
-                self._nested[item] = n
-                return n
-
-        # Item not a nested key, raise
-        raise KeyError(item)
-
-    @classmethod
-    def from_model(cls, model, *fields, **named_fields):
-        """
-        Work-in-progress constructor,
-        consuming fields and values from django model instance.
-        """
-        d = ModelDict()
-
-        if not (fields or named_fields):
-            # Default to all fields
-            fields = [f.attname for f in model._meta.concrete_fields]
-
-        not_found = object()
-
-        for name, field in chain(zip(fields, fields), named_fields.items()):
-            _fields = field.split('__')
-            value = model
-            for i, _field in enumerate(_fields, start=1):
-                # NOTE: we don't want to rely on hasattr here
-                previous_value = value
-                value = getattr(previous_value, _field, not_found)
-
-                if value is not_found:
-                    if _field in dir(previous_value):
-                        raise ValueError(
-                            '{!r}.{} had an AttributeError exception'
-                            .format(previous_value, _field))
-                    else:
-                        raise AttributeError(
-                            '{!r} does not have {!r} attribute'
-                            .format(previous_value, _field))
-
-                elif value is None:
-                    if name not in named_fields:
-                        name = '__'.join(_fields[:i])
-                    break
-
-            d[name] = value
-
-        return d
-
-
-class ModelDictValuesQuerySet(ValuesQuerySet):
-
-    def iterator(self):
-        return (ModelDict(v) for v in super(ModelDictValuesQuerySet,
-                                            self).iterator())
-
-
-class ModelDictQuerySetMixin:
-
-    def dicts(self, *fields):
-        return self._clone(klass=ModelDictValuesQuerySet, setup=True,
-                           _fields=fields)
 
 
 class ModelDictQuerySet(ModelDictQuerySetMixin, QuerySet):
@@ -128,56 +24,6 @@ class ModelDictManagerMixin:
 
     def get_queryset(self):
         return ModelDictQuerySet(self.model, using=self._db)
-
-
-class ExtendedValuesQuerySet(ValuesQuerySet):
-    """
-    Extended `ValuesQuerySet` with support for renaming fields
-    and choice of object class.
-    """
-    _values_class = dict
-
-    @property
-    def named_fields(self):
-        return getattr(self, '_named_fields')
-
-    def rename_fields(self, names):
-        named_fields = self.named_fields
-        if named_fields:
-            names = [named_fields.get(name, name) for name in names]
-        return names
-
-    def iterator(self):
-        # Purge any extra columns that haven't been explicitly asked for
-        extra_names = list(self.query.extra_select)
-        field_names = self.field_names
-        annotation_names = list(self.query.annotation_select)
-
-        # Modified super(); rename fields given in queryset.values() kwargs
-        names = self.rename_fields(extra_names + field_names + annotation_names)
-
-        for row in self.query.get_compiler(self.db).results_iter():
-            yield self._values_class(zip(names, row))
-
-    def _clone(self, klass=None, setup=False, **kwargs):
-        kwargs.update(_named_fields=self.named_fields,
-                      _values_class=self._values_class,
-                      klass=klass,
-                      setup=setup)
-
-        return super()._clone(**kwargs)
-
-
-class ExtendedModelDictQuerySetMixin:
-
-    def dicts(self, *fields, **named_fields):
-        if named_fields:
-            named_fields = {value: key for key, value in named_fields.items()}
-            fields = fields + tuple(named_fields.keys())
-
-        return self._clone(klass=ExtendedValuesQuerySet, setup=True,
-                           _fields=fields, _named_fields=named_fields,
-                           _values_class=ModelDict)
 
 
 class ExtendedQuerySet(ExtendedModelDictQuerySetMixin, QuerySet):

--- a/bananas/utils.py
+++ b/bananas/utils.py
@@ -1,0 +1,99 @@
+from itertools import chain
+
+MISSING = object()
+
+
+class ModelDict(dict):
+
+    _nested = None
+
+    def __getattr__(self, item):
+        """
+        Try to to get attribute as key item.
+        Fallback on prefixed nested keys.
+        Finally fallback on real attribute lookup.
+        """
+        try:
+            return self.__getitem__(item)
+        except KeyError:
+            try:
+                return self.__getnested__(item)
+            except KeyError:
+                return self.__getattribute__(item)
+
+    def __getnested__(self, item):
+        """
+        Find existing items prefixed with given item
+        and return a new ModelDict containing matched keys,
+        stripped from prefix.
+
+        :param str item: Item prefix key to find
+        :return ModelDict:
+        """
+        # Ensure _nested cache
+        if self._nested is None:
+            self._nested = {}
+
+        # Try to get previously accessed/cached nested item
+        value = self._nested.get(item, MISSING)
+
+        if value is not MISSING:
+            # Return previously accessed nested item
+            return value
+
+        else:
+            # Find any keys matching nested prefix
+            prefix = item + '__'
+            keys = [key for key in self.keys() if key.startswith(prefix)]
+
+            if keys:
+                # Construct nested dict of matched keys, stripped from prefix
+                n = ModelDict({key[len(item) + 2:]: self[key] for key in keys})
+
+                # Cache and return
+                self._nested[item] = n
+                return n
+
+        # Item not a nested key, raise
+        raise KeyError(item)
+
+    @classmethod
+    def from_model(cls, model, *fields, **named_fields):
+        """
+        Work-in-progress constructor,
+        consuming fields and values from django model instance.
+        """
+        d = ModelDict()
+
+        if not (fields or named_fields):
+            # Default to all fields
+            fields = [f.attname for f in model._meta.concrete_fields]
+
+        not_found = object()
+
+        for name, field in chain(zip(fields, fields), named_fields.items()):
+            _fields = field.split('__')
+            value = model
+            for i, _field in enumerate(_fields, start=1):
+                # NOTE: we don't want to rely on hasattr here
+                previous_value = value
+                value = getattr(previous_value, _field, not_found)
+
+                if value is not_found:
+                    if _field in dir(previous_value):
+                        raise ValueError(
+                            '{!r}.{} had an AttributeError exception'
+                            .format(previous_value, _field))
+                    else:
+                        raise AttributeError(
+                            '{!r} does not have {!r} attribute'
+                            .format(previous_value, _field))
+
+                elif value is None:
+                    if name not in named_fields:
+                        name = '__'.join(_fields[:i])
+                    break
+
+            d[name] = value
+
+        return d

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -84,6 +84,16 @@ class QuerySetTest(TestCase):
         self.assertNotIn('parent', child)
         self.assertEqual(child.parent.name, self.parent.name)
 
+    def test_dicts_rename(self):
+        self.assertTrue(hasattr(Parent.objects, 'dicts'))
+
+        simple = Simple.objects.all().dicts('name').first()
+        self.assertEqual(simple.name, self.simple.name)
+
+        child = Child.objects.dicts('name', parent='parent__name').order_by('name').first()
+        self.assertEqual(child.name, self.child.name)
+        self.assertEqual(child.parent, self.parent.name)
+
     def test_uuid_model(self):
         first = TestUUIDModel.objects.create(text='first')
 


### PR DESCRIPTION
Django 1.9 removed `ValuesQuerySet`. This PR adds a compatibility layer to handle both 1.8 and 1.9.
