### PR TITLE
Support for URL-encoded database names.

### DIFF
--- a/bananas/url.py
+++ b/bananas/url.py
@@ -24,6 +24,7 @@ You can add your own by running ``register(scheme, module_name)`` before
 parsing.
 """
 from collections import namedtuple
+from urllib.parse import unquote_plus
 
 try:
     # Python 2
@@ -154,7 +155,7 @@ def parse_path(path):
 
     parts = path.strip('/').split('/')
 
-    database = parts[0] if len(parts) else None
+    database = unquote_plus(parts[0]) if len(parts) else None
     schema = parts[1] if len(parts) > 1 else None
 
     return database, schema

--- a/tests/test_db_url.py
+++ b/tests/test_db_url.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from django.test import TestCase
 
 from bananas import url
@@ -73,3 +75,18 @@ class DBURLTest(TestCase):
         self.assertRaises(ValueError, url.parse_path, None)
         self.assertRaisesRegex(Exception, '^Your url is',
                                url.parse_database_url, 'sqlite://:memory:')
+
+    def test_db_url_with_slashes(self):
+        name = quote('/var/db/tweets.sqlite', safe='')
+        conf = url.database_conf_from_url('sqlite3:///{0}'.format(name))
+
+        self.assertDictEqual(conf, {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': '/var/db/tweets.sqlite',
+            'USER': None,
+            'HOST': None,
+            'PORT': None,
+            'PARAMS': {},
+            'SCHEMA': None,
+            'PASSWORD': None,
+        })


### PR DESCRIPTION
Following should be somehow supported, but it isn't because of the slashes confusing the URL parser.

```
sqlite:////var/db/foobar.sqlite
```

This PR solves the problem, by making the parser allow the database name to be URL encoded:

```
sqlite:///%2Fvar%2Fdb%2Ffoobar.sqlite
```