### PR TITLE
Fix button colors in Edge

### DIFF
--- a/bananas/static/admin/css/bananas.css
+++ b/bananas/static/admin/css/bananas.css
@@ -468,7 +468,7 @@ input[type="submit"].default:active,
 }
 
 .button.default,
-.button.default:default,
+.button.default:disabled,
 input[type="submit"].default,
 input[type="submit"].default:disabled,
 .submit-row input.default,


### PR DESCRIPTION
I had accidentally used the `:default` pseudo-class instead of
`:disabled`. This caused some buttons to get the wrong color in browsers
that do not support the `:default` pseudo-class, such as Edge.