### PR TITLE
Expand database url engine mapping to include Django gis backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,10 @@ Currently supported engines are:
  mysql                          django.db.backends.mysql
  oracle                         django.db.backends.oracle
  sqlite, sqlite3                django.db.backends.sqlite3
+ mysqlgis                       django.contrib.gis.db.backends.mysql
+ oraclegis                      django.contrib.gis.db.backends.oracle
+ postgis                        django.contrib.gis.db.backends.postgis
+ spatialite                     django.contrib.gis.db.backends.spatialite
 ==============================  ===========================================
 
 You can add your own by running ``register(scheme, module_name)`` before parsing.

--- a/bananas/url.py
+++ b/bananas/url.py
@@ -18,6 +18,10 @@ Currently supported engines are:
  mysql                          django.db.backends.mysql
  oracle                         django.db.backends.oracle
  sqlite, sqlite3                django.db.backends.sqlite3
+ mysqlgis                       django.contrib.gis.db.backends.mysql
+ oraclegis                      django.contrib.gis.db.backends.oracle
+ postgis                        django.contrib.gis.db.backends.postgis
+ spatialite                     django.contrib.gis.db.backends.spatialite
 ==============================  ===========================================
 
 You can add your own by running ``register(scheme, module_name)`` before
@@ -46,7 +50,11 @@ ENGINE_MAPPING = {
     'mysql': 'django.db.backends.mysql',
     'oracle': 'django.db.backends.oracle',
     'sqlite': Alias('sqlite3'),
-    'sqlite3': 'django.db.backends.sqlite3'
+    'sqlite3': 'django.db.backends.sqlite3',
+    'mysqlgis': 'django.contrib.gis.db.backends.mysql',
+    'oraclegis': 'django.contrib.gis.db.backends.oracle',
+    'postgis': 'django.contrib.gis.db.backends.postgis',
+    'spatialite': 'django.contrib.gis.db.backends.spatialite'
 }
 
 


### PR DESCRIPTION
Worth noting is that the namings `mysqlgis` and `oraclegis` might feel a bit sketchy, as otherwise they'd clash.

However, it does still enable a 1 to 1 mapping and is somewhat describable. Let me know if you'd prefer any other key names for them.