### PR TITLE
Fix issue with register admin view for django app nested in package

### DIFF
--- a/bananas/admin/extension.py
+++ b/bananas/admin/extension.py
@@ -167,8 +167,8 @@ def register(view=None, *, admin_site=None, admin_class=ModelAdminView):
 
     def wrapped(inner_view):
         module = inner_view.__module__
-        app_package = module[: module.index(".admin")]
-        app_config = apps.get_app_config(app_package)
+        app_label = re.search(r'\.?(\w+)\.admin', module).group(1)
+        app_config = apps.get_app_config(app_label)
 
         label = getattr(inner_view, "label", None)
         if not label:

--- a/bananas/admin/extension.py
+++ b/bananas/admin/extension.py
@@ -167,7 +167,7 @@ def register(view=None, *, admin_site=None, admin_class=ModelAdminView):
 
     def wrapped(inner_view):
         module = inner_view.__module__
-        app_label = re.search(r'\.?(\w+)\.admin', module).group(1)
+        app_label = re.search(r"\.?(\w+)\.admin", module).group(1)
         app_config = apps.get_app_config(app_label)
 
         label = getattr(inner_view, "label", None)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -124,6 +124,16 @@ class AdminTest(AdminBaseTest):
         self.assertIsNotNone(model_admin)
         self.assertIsInstance(model_admin, SpecialModelAdmin)
 
+    @reset_admin_registry
+    def test_register_app_nested_in_package(self):
+        @admin.register
+        class MyAdminViewRegisteredInNestedApp(admin.AdminView):
+            __module__ = "somepackage.tests.admin"
+
+        model_admin = get_model_admin_from_registry(MyAdminViewRegisteredInNestedApp)
+        self.assertIsNotNone(model_admin)
+        self.assertIsInstance(model_admin, admin.ModelAdminView)
+
     def assert_unauthorized(self, url):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
If try to register an admin view in an app that is nested in another package you will get `LookupError` since `django.apps.get_app_config()` expects an app label as the argument (not dotted path).

For example
```python
INSTALLED_APPS = [
    ...
    'somepackage.someapp',
]
```

somepackage/someapp/admin.py
```python
from bananas import admin, AdminView

@admin.register
class MyView(AdminView):
    ...
```

relevant trace:
```
File "/usr/local/lib/python3.7/site-packages/bananas/admin.py", line 216, in register
    return wrapped(view)
  File "/usr/local/lib/python3.7/site-packages/bananas/admin.py", line 174, in wrapped
    app_config = apps.get_app_config(app_package)
  File "/usr/local/lib/python3.7/site-packages/django/apps/registry.py", line 159, in get_app_config
    raise LookupError(message)
LookupError: No installed app with label 'somepackage.someapp'. Did you mean 'someapp'?
```