### PR TITLE
Fix admin CSS in Django 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PYTHON=3
 FROM python:${PYTHON}
 
 # Install system dependencies
-ARG DJANGO=">=2.0.9,<2.1"
+ARG DJANGO=">=2.0.9,<2.3"
 RUN apt-get update && apt-get install -y \
         gettext && \
     pip install --pre "Django${DJANGO}"

--- a/bananas/static/admin/bananas/css/bananas.css
+++ b/bananas/static/admin/bananas/css/bananas.css
@@ -62,11 +62,16 @@ body:not(.login) #header {
 }
 
 #header {
+  display: block;
   background-color: #417690 /* fallback */;
   background-color: var(--theme-color);
   color: white;
   outline: 0;
   overflow: visible;
+}
+
+.login #header {
+  padding: 5px 16px;
 }
 
 #branding {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       args:
-        DJANGO: ">=2.0.9,<2.1"
+        DJANGO: ">=2.0.9,<2.3"
     command: ["runserver", "0.0.0.0:8000"]
     stdin_open: true
     tty: true


### PR DESCRIPTION
![Screenshot from 2019-06-24 11-39-19](https://user-images.githubusercontent.com/2142817/60009275-e4793700-9675-11e9-9aa6-94d9b1f735e4.png)
Fix admin CSS in Django 2.2

- This Django commit broke the sidebar:

  https://github.com/django/django/commit/5008d59a2a8b9df09737fc05c9e343146a348a90

  The nav did not appear at all, and the branding ended up in the middle
  of the sidebar. This is because they changed `#header` to `display:
  flex;`. This commit changes it back to `display: block;`.

- This Django commit made the login header thicker:

  https://github.com/django/django/commit/c41e6c4eb8049a1f0efcfd7c7fc3b3ca11207b5a#diff-0f923ceac93fbf865e1657459d91d069

  This commit changes back to the old, thinner padding.
