### PR TITLE
Fix deprecation warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ Django admin API for use with django-bananas.js (react admin site)
     from bananas.admin.api.schemas import schema
     from bananas.admin.api.views import BananasAdminAPI
     from bananas.lazy import lazy_title
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
     from rest_framework import viewsets
 
     class CustomAdminAPI(BananasAdminAPI):

--- a/bananas/admin/api/serializers.py
+++ b/bananas/admin/api/serializers.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import password_validators_help_texts
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from bananas.admin.api.schemas import schema_serializer_method

--- a/bananas/admin/api/views.py
+++ b/bananas/admin/api/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth import (
     update_session_auth_hash,
 )
 from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response

--- a/bananas/admin/extension.py
+++ b/bananas/admin/extension.py
@@ -10,7 +10,7 @@ from django.contrib.admin.sites import site as django_admin_site
 from django.contrib.auth.decorators import permission_required, user_passes_test
 from django.db.models import Model
 from django.shortcuts import render
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -130,8 +130,8 @@ class ModelAdminView(ModelAdmin):
         context.update(
             {
                 "app_label": opts.app_label,
-                "model_name": force_text(opts.verbose_name_plural),
-                "title": force_text(opts.verbose_name_plural),
+                "model_name": force_str(opts.verbose_name_plural),
+                "title": force_str(opts.verbose_name_plural),
                 "cl": {"opts": opts},  # change_list.html requirement
                 "opts": opts,  # change_form.html requirement
                 "media": self.media,

--- a/bananas/models.py
+++ b/bananas/models.py
@@ -7,7 +7,7 @@ from itertools import chain
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 MISSING = object()
 

--- a/example/example/api.py
+++ b/example/example/api.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import DjangoModelPermissions

--- a/tests/admin_api.py
+++ b/tests/admin_api.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response


### PR DESCRIPTION
* `ugettext_lazy` -> `gettext_lazy` (Will be removed in Django 4.0)
* `force_text` -> `force_str` (Will be removed in Django 4.0)