### PR TITLE
Implement API fencing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 .PHONY: test		# runs tests
 test:
-	python -X dev -Wd -m coverage run runtests.py
+	python -X dev -Wd runtests.py $(test)
 
 .PHONY: test_all		# runs tests using detox, combines coverage and reports it
 test_all:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 .PHONY: test		# runs tests
 test:
-	python -X dev -Wd runtests.py $(test)
+	python -X dev -Wd -m coverage run runtests.py $(test)
 
 .PHONY: test_all		# runs tests using detox, combines coverage and reports it
 test_all:

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ django-bananas is on PyPI, so just run:
 
     python3 -m pip install django-bananas
 
-Using the admin feature requires djangorestframework and drf-yasg and it's
-recommended to install django-bananas with the `drf` extra to keep those in
-sync:
+Using DRF specific features like Bananas Admin and fencing requires
+djangorestframework and drf-yasg and it's recommended to install django-bananas
+with the ``drf`` extra to keep those in sync:
 
 .. code-block:: bash
 
@@ -210,7 +210,7 @@ Custom django admin stylesheet.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Django admin API for use with django-bananas.js (react admin site). This feature
-requires installation with the `drf` extra.
+requires installation with the ``drf`` extra.
 
 .. code-block:: py
 
@@ -414,8 +414,12 @@ Is useful for getting the content of secrets stored in files. One usecase is `do
 bananas.drf.fencing - Fence DRF views with HTTP conditional headers
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Microframework for guarding DRF views with HTTP conditionals. Built to work well
-in conjunction with ``BananasAdminAPI`` and ``TimeStampedModel``.
+Building blocks for composing HTTP conditionals to guard DRF views. Built to
+work well in conjunction with ``BananasAdminAPI`` and ``TimeStampedModel``. This
+feature requires installation with the ``drf`` extra.
+
+Fences add a header parameter to the exposed OpenAPI schema if you're using
+drf-yasg.
 
 ``allow_if_unmodified_since``
 =============================
@@ -435,7 +439,6 @@ requires running Django with timezone support enabled, ``USE_TZ = TRUE``.
         fence = allow_if_unmodified_since()
         serializer_class = ItemSerializer
 
-
 ``allow_if_match``
 ==================
 
@@ -450,6 +453,41 @@ of the updated instance.
     class ItemAPI(FencedUpdateModelMixin, GenericViewSet):
         fence = allow_if_match(operator.attrgetter("version"))
         serializer_class = ItemSerializer
+
+``Fence``
+=========
+
+Example implementing a fence for ``If-Modified-Since``:
+
+.. code-block:: python
+
+    import operator
+    from drf_yasg import openapi
+    from rest_framework import status
+    from rest_framework.exceptions import APIException
+    from bananas.drf.fencing import Fence, header_date_parser, parse_date_modified
+
+    class NotModified(APIException):
+        status_code = status.HTTP_304_NOT_MODIFIED
+        default_detail = "An HTTP precondition failed"
+        default_code = "not_modified"
+
+    allow_if_not_modified_since = Fence(
+        get_token=header_date_parser("If-Modified-Since"),
+        compare=operator.gt,
+        get_version=parse_date_modified,
+        openapi_parameter=openapi.Parameter(
+            in_=openapi.IN_HEADER,
+            name="If-Modified-Since",
+            type=openapi.TYPE_STRING,
+            required=True,
+            description=(
+                "Time of last edit of the client's representation of the resource in "
+                "RFC7231 format."
+            ),
+        ),
+        rejection=NotModified("The resource is unmodified"),
+    )
 
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -334,6 +334,7 @@ provides:
 
 
 :get_bool:
+
     returns ``True`` if the environment variable value is any of,
     case-insensitive:
 
@@ -399,3 +400,44 @@ Is useful for getting the content of secrets stored in files. One usecase is `do
 
     >>> secrets.get_secret("hemlis")
     "topsecret"
+
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+bananas.drf.fencing - Fence DRF views with HTTP conditional headers
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Microframework for guarding DRF views with HTTP conditionals. Built to work well
+in conjunction with ``BananasAdminAPI`` and ``TimeStampedModel``.
+
+``allow_if_unmodified_since``
+=============================
+
+Make a view-set for a ``TimeStampedModel`` only accept updates when
+``If-Unmodified-Since`` specifies a date before the ``date_modified`` of the
+updated instance.
+
+Due to comparing datetime instances, using ``allow_if_unmodified_since``
+requires running Django with timezone support enabled, ``USE_TZ = TRUE``.
+
+.. code-block:: python
+
+    from bananas.drf.fencing import FencedUpdateModelMixin, allow_if_unmodified_since
+
+    class ItemAPI(FencedUpdateModelMixin, GenericViewSet):
+        fence = allow_if_unmodified_since()
+        serializer_class = ItemSerializer
+
+
+``allow_if_match``
+==================
+
+Make a view-set that requires passing a version string in ``If-Match`` and
+rejects requests when the given version does not match the ``version`` attribute
+of the updated instance.
+
+.. code-block:: python
+
+    from bananas.drf.fencing import FencedUpdateModelMixin, allow_if_match
+
+    class ItemAPI(FencedUpdateModelMixin, GenericViewSet):
+        fence = allow_if_match(operator.attrgetter("version"))
+        serializer_class = ItemSerializer

--- a/bananas/drf/errors.py
+++ b/bananas/drf/errors.py
@@ -1,0 +1,14 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class PreconditionFailed(APIException):
+    status_code = status.HTTP_412_PRECONDITION_FAILED
+    default_detail = "An HTTP precondition failed"
+    default_code = "precondition_failed"
+
+
+class BadRequest(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "Validation failed"
+    default_code = "bad_request"

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -6,7 +6,6 @@ from typing import Callable, FrozenSet, Generic, Optional, TypeVar
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from rest_framework import mixins
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.request import Request
 from rest_framework.serializers import BaseSerializer, ModelSerializer

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -44,6 +44,9 @@ class Fence(abc.ABC, Generic[InstanceType, TokenType]):
     def check(self, request: Request, instance: InstanceType) -> bool:
         version = self._get_version(instance)
         if version is None:
+            # We might want to expose control of this behavior. For if-unmodified-since
+            # it makes sense to return true here, but it might not for
+            # if-modified-since other conditionals.
             return True
         return self._compare(version, self._get_token(request))
 
@@ -62,7 +65,7 @@ class FencedUpdateModelMixin(abc.ABC):
         assert isinstance(serializer, ModelSerializer)
         if not self.fence.check(self.request, serializer.instance):
             raise errors.PreconditionFailed(
-                "The resource has been concurrently modified"
+                "The resource does not fulfill the given preconditions"
             )
         super().perform_update(serializer)  # type: ignore[misc]
 

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from drf_yasg import openapi
 from drf_yasg.inspectors import SwaggerAutoSchema
-from drf_yasg.utils import merge_params, swagger_auto_schema
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -133,7 +133,9 @@ def allow_if_unmodified_since() -> Fence[TimeStampedModel, datetime.datetime]:
             name="If-Unmodified-Since",
             type=openapi.TYPE_STRING,
             required=True,
-            description="Time of last edit of the resource known to the client.",
+            description=(
+                "Time of last edit of the client's representation of the resource."
+            ),
         ),
     )
 

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -1,0 +1,126 @@
+import abc
+import datetime
+import operator
+from functools import wraps
+from typing import Callable, FrozenSet, Generic, Optional, TypeVar
+
+from rest_framework import mixins
+from rest_framework.request import Request
+from rest_framework.serializers import BaseSerializer, ModelSerializer
+from rest_framework.viewsets import GenericViewSet
+from typing_extensions import Final, final
+
+from bananas.models import TimeStampedModel
+
+from . import errors
+from .utils import HeaderError, parse_header_datetime, parse_header_etags
+
+__all__ = (
+    "Fence",
+    "FencedUpdateModelMixin",
+    "header_date_parser",
+    "parse_date_modified",
+    "allow_if_unmodified_since",
+    "header_etag_parser",
+    "allow_if_match",
+)
+
+TokenType = TypeVar("TokenType")
+InstanceType = TypeVar("InstanceType")
+
+
+@final
+class Fence(abc.ABC, Generic[InstanceType, TokenType]):
+    def __init__(
+        self,
+        get_token: Callable[[Request], TokenType],
+        compare: Callable[[TokenType, TokenType], bool],
+        get_version: Callable[[InstanceType], Optional[TokenType]],
+    ) -> None:
+        self._get_token: Final = get_token
+        self._compare: Final = compare
+        self._get_version: Final = get_version
+
+    def check(self, request: Request, instance: InstanceType) -> bool:
+        version = self._get_version(instance)
+        if version is None:
+            return True
+        return self._compare(version, self._get_token(request))
+
+
+class FencedUpdateModelMixin(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def fence(self) -> Fence:
+        ...
+
+    def perform_update(self, serializer: BaseSerializer) -> None:
+        # mypy's advanced self types don't work with super calls so we use an assertion
+        # here instead.
+        assert isinstance(self, GenericViewSet)
+        assert isinstance(self, mixins.UpdateModelMixin)
+        assert isinstance(serializer, ModelSerializer)
+        if not self.fence.check(self.request, serializer.instance):
+            raise errors.PreconditionFailed(
+                "The resource has been concurrently modified"
+            )
+        super().perform_update(serializer)  # type: ignore[misc]
+
+
+def header_date_parser(header: str) -> Callable[[Request], datetime.datetime]:
+    def parse(request: Request) -> datetime.datetime:
+        try:
+            return parse_header_datetime(request, header)
+        except HeaderError as e:
+            raise e.as_api_error()
+
+    return parse
+
+
+def parse_date_modified(instance: TimeStampedModel) -> Optional[datetime.datetime]:
+    return (
+        instance.date_modified.replace(microsecond=0)
+        if instance.date_modified
+        else None
+    )
+
+
+allow_if_unmodified_since: Final = Fence[TimeStampedModel, datetime.datetime](
+    get_token=header_date_parser("If-Unmodified-Since"),
+    compare=operator.le,
+    get_version=parse_date_modified,
+)
+
+
+def header_etag_parser(header: str) -> Callable[[Request], FrozenSet[str]]:
+    def parse(request: Request) -> FrozenSet[str]:
+        try:
+            return parse_header_etags(request, header)
+        except HeaderError as e:
+            raise e.as_api_error()
+
+    return parse
+
+
+T = TypeVar("T")
+
+
+def as_set(
+    fn: Callable[[InstanceType], Optional[T]]
+) -> Callable[[InstanceType], Optional[FrozenSet[T]]]:
+    @wraps(fn)
+    def wrapper(instance: InstanceType) -> Optional[FrozenSet[T]]:
+        version = fn(instance)
+        return None if version is None else frozenset({version})
+
+    return wrapper
+
+
+def allow_if_match(
+    version_getter: Callable[[InstanceType], Optional[str]]
+) -> Fence[InstanceType, FrozenSet[str]]:
+    return Fence(
+        get_token=header_etag_parser("If-Match"),
+        compare=operator.le,
+        get_version=as_set(version_getter),
+    )

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -66,15 +66,12 @@ class FenceAwareSwaggerAutoSchema(SwaggerAutoSchema):
         self, parameters: List[openapi.Parameter]
     ) -> List[openapi.Parameter]:
         parameters = super().add_manual_parameters(parameters)
-        fence_params = (
-            [self.view.fence.openapi_parameter]
-            if (
-                isinstance(self.view, FencedUpdateModelMixin)
-                and self.method in self.update_methods
-            )
-            else []
-        )
-        return merge_params(fence_params, parameters)
+        if (
+            isinstance(self.view, FencedUpdateModelMixin)
+            and self.method in self.update_methods
+        ):
+            return parameters + [self.view.fence.openapi_parameter]
+        return parameters
 
 
 class FencedUpdateModelMixin(UpdateModelMixin, abc.ABC):

--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, FrozenSet, Generic, List, NoReturn, Optional, 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from drf_yasg import openapi
-from drf_yasg.inspectors import SwaggerAutoSchema
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.request import Request
@@ -16,6 +15,7 @@ from rest_framework.serializers import BaseSerializer, ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 from typing_extensions import Final, final
 
+from bananas.admin.api.schemas.yasg import BananasSwaggerSchema
 from bananas.models import TimeStampedModel
 
 from . import errors
@@ -71,7 +71,7 @@ class Fence(abc.ABC, Generic[InstanceType, TokenType]):
             self.reject()
 
 
-class FenceAwareSwaggerAutoSchema(SwaggerAutoSchema):
+class FenceAwareSwaggerAutoSchema(BananasSwaggerSchema):
     update_methods = ("PUT", "PATCH")
 
     def add_manual_parameters(
@@ -103,6 +103,10 @@ class FencedUpdateModelMixin(UpdateModelMixin, abc.ABC):
     @swagger_auto_schema(auto_schema=FenceAwareSwaggerAutoSchema)
     def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().update(request, *args, **kwargs)
+
+    @swagger_auto_schema(auto_schema=FenceAwareSwaggerAutoSchema)
+    def partial_update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return super().partial_update(request, *args, **kwargs)
 
 
 def header_date_parser(header: str) -> Callable[[Request], datetime.datetime]:

--- a/bananas/drf/utils.py
+++ b/bananas/drf/utils.py
@@ -51,9 +51,10 @@ def parse_header_datetime(request: Request, header: str) -> datetime.datetime:
 
 # This can be inlined with a walrus expression but we need to keep support for pre 3.8.
 def clean_tags(tags: Iterable[str]) -> Iterable[str]:
-    for tag in (tag.strip().strip('"') for tag in tags):
-        if tag:
-            yield tag
+    for tag in tags:
+        cleaned = tag.strip().strip('"')
+        if cleaned:
+            yield cleaned
 
 
 def parse_header_etags(request: Request, header: str) -> FrozenSet[str]:

--- a/bananas/drf/utils.py
+++ b/bananas/drf/utils.py
@@ -1,0 +1,67 @@
+import datetime
+from typing import FrozenSet, Iterable
+
+from django.utils.http import parse_http_date
+from rest_framework.request import Request
+
+from .errors import BadRequest
+
+__all__ = (
+    "HeaderError",
+    "MissingHeader",
+    "InvalidHeader",
+    "parse_header_datetime",
+    "parse_header_etags",
+)
+
+
+class HeaderError(ValueError):
+    code = "invalid_header"
+
+    def as_api_error(self) -> BadRequest:
+        return BadRequest(detail=str(self), code=self.code)
+
+
+class MissingHeader(HeaderError):
+    code = "missing_header"
+
+    def __init__(self, header: str) -> None:
+        self.header = header
+        super().__init__(f"Header missing in request: {header}")
+
+
+class InvalidHeader(HeaderError):
+    def __init__(self, header: str) -> None:
+        self.header = header
+        super().__init__(f"Malformed header in request: {header}")
+
+
+def parse_header_datetime(request: Request, header: str) -> datetime.datetime:
+    try:
+        value = request.headers[header]
+    except KeyError:
+        raise MissingHeader(header)
+    try:
+        return datetime.datetime.fromtimestamp(
+            parse_http_date(value), tz=datetime.timezone.utc
+        )
+    except ValueError as e:
+        raise InvalidHeader(header) from e
+
+
+# This can be inlined with a walrus expression but we need to keep support for pre 3.8.
+def clean_tags(tags: Iterable[str]) -> Iterable[str]:
+    for tag in (tag.strip().strip('"') for tag in tags):
+        if tag:
+            yield tag
+
+
+def parse_header_etags(request: Request, header: str) -> FrozenSet[str]:
+    try:
+        parts = request.headers[header].split(",")
+    except KeyError:
+        raise MissingHeader(header)
+    tags = frozenset(clean_tags(parts))
+    if not tags:
+        raise InvalidHeader(header)
+    return tags

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ exclude =
 zip_safe = False
 install_requires =
     Django>=2.2
+    typing-extensions>=3.7.4.3
 
 [options.extras_require]
 test =
@@ -106,3 +107,6 @@ plugins =
 
 [mypy.plugins.django-stubs]
 django_settings_module = tests.settings
+
+[mypy-bananas.drf.*]
+ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ zip_safe = False
 install_requires =
     Django>=2.2
     typing-extensions>=3.7.4.3
+    drf-yasg>=1.20.0
 
 [options.extras_require]
 test =
@@ -116,3 +117,6 @@ ignore_errors = False
 
 [mypy-tests.drf.fenced_api]
 ignore_errors = False
+
+[mypy-drf_yasg.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,9 @@ show_missing = True
 exclude_lines =
     pragma: no cover
     if __name__ == .__main__.:
+    ^\s*\.\.\.
+    if TYPE_CHECKING:
+    raise NotImplementedError
 
 [isort]
 line_length = 88
@@ -109,4 +112,7 @@ plugins =
 django_settings_module = tests.settings
 
 [mypy-bananas.drf.*]
+ignore_errors = False
+
+[mypy-tests.drf.fenced_api]
 ignore_errors = False

--- a/tests/drf/fenced_api.py
+++ b/tests/drf/fenced_api.py
@@ -1,3 +1,5 @@
+import operator
+
 from django.urls import include, re_path
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.routers import DefaultRouter
@@ -5,7 +7,11 @@ from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import GenericViewSet
 from tests.models import Parent
 
-from bananas.drf.fencing import FencedUpdateModelMixin, allow_if_unmodified_since
+from bananas.drf.fencing import (
+    FencedUpdateModelMixin,
+    allow_if_match,
+    allow_if_unmodified_since,
+)
 
 
 class SimpleSerializer(ModelSerializer):
@@ -14,7 +20,9 @@ class SimpleSerializer(ModelSerializer):
         fields = ("name",)
 
 
-class FencedAPI(FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet):
+class AllowIfUnmodifiedSinceAPI(
+    FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet
+):
     fence = allow_if_unmodified_since
     serializer_class = SimpleSerializer
 
@@ -22,7 +30,16 @@ class FencedAPI(FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet):
         return Parent.objects.all()
 
 
-router = DefaultRouter()
-router.register(r"fenced", FencedAPI, "fenced")
+class AllowIfMatchAPI(FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet):
+    fence = allow_if_match(operator.attrgetter("version"))
+    serializer_class = SimpleSerializer
 
-urlpatterns = [re_path("", include(router.urls))]
+    def get_queryset(self):
+        return Parent.objects.all()
+
+
+router = DefaultRouter()
+router.register(r"if-unmodified", AllowIfUnmodifiedSinceAPI, "if-unmodified")
+router.register(r"if-match", AllowIfMatchAPI, "if-match")
+
+urlpatterns = [re_path("fenced", include(router.urls))]

--- a/tests/drf/fenced_api.py
+++ b/tests/drf/fenced_api.py
@@ -1,0 +1,28 @@
+from django.urls import include, re_path
+from rest_framework.mixins import UpdateModelMixin
+from rest_framework.routers import DefaultRouter
+from rest_framework.serializers import ModelSerializer
+from rest_framework.viewsets import GenericViewSet
+from tests.models import Parent
+
+from bananas.drf.fencing import FencedUpdateModelMixin, allow_if_unmodified_since
+
+
+class SimpleSerializer(ModelSerializer):
+    class Meta:
+        model = Parent
+        fields = ("name",)
+
+
+class FencedAPI(FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet):
+    fence = allow_if_unmodified_since
+    serializer_class = SimpleSerializer
+
+    def get_queryset(self):
+        return Parent.objects.all()
+
+
+router = DefaultRouter()
+router.register(r"fenced", FencedAPI, "fenced")
+
+urlpatterns = [re_path("", include(router.urls))]

--- a/tests/drf/fenced_api.py
+++ b/tests/drf/fenced_api.py
@@ -23,7 +23,7 @@ class SimpleSerializer(ModelSerializer):
 class AllowIfUnmodifiedSinceAPI(
     FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet
 ):
-    fence = allow_if_unmodified_since
+    fence = allow_if_unmodified_since()
     serializer_class = SimpleSerializer
 
     def get_queryset(self):

--- a/tests/drf/fenced_api.py
+++ b/tests/drf/fenced_api.py
@@ -20,9 +20,7 @@ class SimpleSerializer(ModelSerializer):
         fields = ("name",)
 
 
-class AllowIfUnmodifiedSinceAPI(
-    FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet
-):
+class AllowIfUnmodifiedSinceAPI(FencedUpdateModelMixin, GenericViewSet):
     fence = allow_if_unmodified_since()
     serializer_class = SimpleSerializer
 
@@ -30,7 +28,7 @@ class AllowIfUnmodifiedSinceAPI(
         return Parent.objects.all()
 
 
-class AllowIfMatchAPI(FencedUpdateModelMixin, UpdateModelMixin, GenericViewSet):
+class AllowIfMatchAPI(FencedUpdateModelMixin, GenericViewSet):
     fence = allow_if_match(operator.attrgetter("version"))
     serializer_class = SimpleSerializer
 

--- a/tests/drf/request.py
+++ b/tests/drf/request.py
@@ -1,0 +1,12 @@
+from typing import Any, Mapping, Optional, cast
+
+from rest_framework.request import Request
+
+
+class FakeRequest:
+    def __init__(self, headers: Optional[Mapping[str, str]] = None) -> None:
+        self.headers = headers or {}
+
+    @classmethod
+    def fake(cls, *args: Any, **kwargs: Any) -> Request:
+        return cast(Request, cls(*args, **kwargs))

--- a/tests/drf/test_fenced_api.py
+++ b/tests/drf/test_fenced_api.py
@@ -1,4 +1,5 @@
-from django.test import TestCase
+from functools import partial
+
 from django.urls import reverse
 from django.utils.http import http_date
 from rest_framework import status
@@ -6,11 +7,12 @@ from rest_framework.test import APITestCase
 from tests.models import Parent
 
 
-class TestFencedAPI(APITestCase):
+class TestAllowIfUnmodifiedSince(APITestCase):
+    url = partial(reverse, "if-unmodified-detail")
+
     def test_returns_bad_request_for_missing_header(self):
         item = Parent.objects.create()
-        url = reverse("fenced-detail", args=(item.pk,))
-        response = self.client.put(url, data={"name": "Great!"})
+        response = self.client.put(self.url(args=(item.pk,)), data={"name": "Great!"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json()["detail"], "Header missing in request: If-Unmodified-Since"
@@ -18,9 +20,8 @@ class TestFencedAPI(APITestCase):
 
     def test_returns_bad_request_for_invalid_header(self):
         item = Parent.objects.create()
-        url = reverse("fenced-detail", args=(item.pk,))
         response = self.client.put(
-            url,
+            self.url(args=(item.pk,)),
             data={"name": "Great!"},
             HTTP_IF_UNMODIFIED_SINCE="",
         )
@@ -32,24 +33,93 @@ class TestFencedAPI(APITestCase):
 
     def test_returns_precondition_failed_for_expired_token(self):
         item = Parent.objects.create()
-        url = reverse("fenced-detail", args=(item.pk,))
         response = self.client.put(
-            url,
+            self.url(args=(item.pk,)),
             data={"name": "Great!"},
             HTTP_IF_UNMODIFIED_SINCE=http_date(item.date_modified.timestamp() - 1),
         )
         self.assertEqual(response.status_code, status.HTTP_412_PRECONDITION_FAILED)
         self.assertEqual(
-            response.json()["detail"], "The resource has been concurrently modified"
+            response.json()["detail"],
+            "The resource does not fulfill the given preconditions",
         )
 
     def test_allows_request_for_valid_token(self):
         item = Parent.objects.create()
-        url = reverse("fenced-detail", args=(item.pk,))
         response = self.client.put(
-            url,
+            self.url(args=(item.pk,)),
             data={"name": "Great!"},
             HTTP_IF_UNMODIFIED_SINCE=http_date(item.date_modified.timestamp()),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.json(), {"name": "Great!"})
+
+
+class TestAllowIfMatch(APITestCase):
+    url = partial(reverse, "if-match-detail")
+
+    def test_returns_bad_request_for_missing_header(self):
+        item = Parent.objects.create()
+        response = self.client.put(self.url(args=(item.pk,)), data={"name": "Great!"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["detail"], "Header missing in request: If-Match"
+        )
+
+    def test_returns_bad_request_for_invalid_header(self):
+        item = Parent.objects.create()
+        response = self.client.put(
+            self.url(args=(item.pk,)),
+            data={"name": "Great!"},
+            HTTP_IF_MATCH="",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["detail"], "Malformed header in request: If-Match"
+        )
+
+    def test_returns_precondition_failed_for_mismatching_token_set(self):
+        item = Parent.objects.create()
+        response = self.client.put(
+            self.url(args=(item.pk,)),
+            data={"name": "Great!"},
+            HTTP_IF_MATCH='"abc123", "abc321", "abc123"',
+        )
+        self.assertEqual(response.status_code, status.HTTP_412_PRECONDITION_FAILED)
+        self.assertEqual(
+            response.json()["detail"],
+            "The resource does not fulfill the given preconditions",
+        )
+
+    def test_returns_precondition_failed_for_mismatching_single_token(self):
+        item = Parent.objects.create()
+        response = self.client.put(
+            self.url(args=(item.pk,)),
+            data={"name": "Great!"},
+            HTTP_IF_MATCH='"abc123"',
+        )
+        self.assertEqual(response.status_code, status.HTTP_412_PRECONDITION_FAILED)
+        self.assertEqual(
+            response.json()["detail"],
+            "The resource does not fulfill the given preconditions",
+        )
+
+    def test_allows_request_for_single_valid_token(self):
+        item = Parent.objects.create()
+        response = self.client.put(
+            self.url(args=(item.pk,)),
+            data={"name": "Great!"},
+            HTTP_IF_MATCH=item.version,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.json(), {"name": "Great!"})
+
+    def test_allows_request_for_set_with_matching_token(self):
+        item = Parent.objects.create()
+        response = self.client.put(
+            self.url(args=(item.pk,)),
+            data={"name": "Great!"},
+            HTTP_IF_MATCH='"{}", "abc123"'.format(item.version),
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(response.json(), {"name": "Great!"})

--- a/tests/drf/test_fenced_api.py
+++ b/tests/drf/test_fenced_api.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.http import http_date
+from rest_framework import status
+from rest_framework.test import APITestCase
+from tests.models import Parent
+
+
+class TestFencedAPI(APITestCase):
+    def test_returns_bad_request_for_missing_header(self):
+        item = Parent.objects.create()
+        url = reverse("fenced-detail", args=(item.pk,))
+        response = self.client.put(url, data={"name": "Great!"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["detail"], "Header missing in request: If-Unmodified-Since"
+        )
+
+    def test_returns_bad_request_for_invalid_header(self):
+        item = Parent.objects.create()
+        url = reverse("fenced-detail", args=(item.pk,))
+        response = self.client.put(
+            url,
+            data={"name": "Great!"},
+            HTTP_IF_UNMODIFIED_SINCE="",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["detail"],
+            "Malformed header in request: If-Unmodified-Since",
+        )
+
+    def test_returns_precondition_failed_for_expired_token(self):
+        item = Parent.objects.create()
+        url = reverse("fenced-detail", args=(item.pk,))
+        response = self.client.put(
+            url,
+            data={"name": "Great!"},
+            HTTP_IF_UNMODIFIED_SINCE=http_date(item.date_modified.timestamp() - 1),
+        )
+        self.assertEqual(response.status_code, status.HTTP_412_PRECONDITION_FAILED)
+        self.assertEqual(
+            response.json()["detail"], "The resource has been concurrently modified"
+        )
+
+    def test_allows_request_for_valid_token(self):
+        item = Parent.objects.create()
+        url = reverse("fenced-detail", args=(item.pk,))
+        response = self.client.put(
+            url,
+            data={"name": "Great!"},
+            HTTP_IF_UNMODIFIED_SINCE=http_date(item.date_modified.timestamp()),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.json(), {"name": "Great!"})

--- a/tests/drf/test_fencing.py
+++ b/tests/drf/test_fencing.py
@@ -1,0 +1,118 @@
+import datetime
+import operator
+from unittest import TestCase
+
+from django.utils.http import http_date
+from rest_framework.exceptions import ValidationError
+
+from bananas.drf.fencing import (
+    Fence,
+    header_date_parser,
+    header_etag_parser,
+    parse_date_modified,
+)
+from bananas.models import TimeStampedModel
+
+from .request import FakeRequest
+
+
+class TestFence(TestCase):
+    def test_check_propagates_error_from_get_token(self):
+        error = RuntimeError()
+
+        def get_token(_request):
+            raise error
+
+        def get_version(_instance):
+            return "a"
+
+        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            fence.check(FakeRequest.fake(), "a")
+
+        self.assertIs(exc_info.exception, error)
+
+    def test_check_propagates_error_from_get_version(self):
+        error = RuntimeError()
+
+        def get_token(_request):
+            return "a"
+
+        def get_version(_instance):
+            raise error
+
+        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            fence.check(FakeRequest.fake(), "a")
+
+        self.assertIs(exc_info.exception, error)
+
+    def test_check_returns_true_for_valid_token(self):
+        def get_token(_request):
+            return "a"
+
+        def get_version(_instance):
+            return "a"
+
+        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+
+        self.assertIs(fence.check(FakeRequest.fake(), "a"), True)
+
+    def test_check_returns_false_for_invalid_token(self):
+        def get_token(_request):
+            return "a"
+
+        def get_version(_instance):
+            return "b"
+
+        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+
+        self.assertIs(fence.check(FakeRequest.fake(), "a"), False)
+
+
+class TestHeaderDateParser(TestCase):
+    def test_reraises_value_error_as_validation_error(self):
+        get_header = header_date_parser("header")
+        with self.assertRaises(ValidationError) as exc_info:
+            get_header(FakeRequest.fake())
+        self.assertEqual(exc_info.exception.detail[0].code, "missing_header")
+
+    def test_can_get_parsed_header_datetime(self):
+        dt = datetime.datetime(2021, 1, 14, 17, 30, 1, tzinfo=datetime.timezone.utc)
+        request = FakeRequest.fake(headers={"header": http_date(dt.timestamp())})
+        parsed = header_date_parser("header")(request)
+        self.assertEqual(parsed, dt)
+
+
+class TestDateModifiedGetter(TestCase):
+    def test_can_get_date_modified(self):
+        class A(TimeStampedModel):
+            date_modified = "value"
+
+        self.assertEqual(parse_date_modified(A()), "value")
+
+
+class TestHeaderEtagParser(TestCase):
+    def test_can_parse_multiple_etags(self):
+        request = FakeRequest.fake(headers={"If-Match": '"a", "b"'})
+        self.assertSetEqual(header_etag_parser("If-Match")(request), {"a", "b"})
+
+    def test_can_parse_single_etag(self):
+        request = FakeRequest.fake(headers={"If-Match": '"a"'})
+        self.assertSetEqual(header_etag_parser("If-Match")(request), {"a"})
+
+    def test_raises_validation_error_for_missing_header(self):
+        request = FakeRequest.fake()
+        parser = header_etag_parser("If-Match")
+        with self.assertRaises(ValidationError) as exc_info:
+            parser(request)
+        self.assertEqual(exc_info.exception.detail[0].code, "missing_header")
+
+    def test_raises_validation_error_for_invalid_header(self):
+        request = FakeRequest.fake(headers={"If-Match": ""})
+        parser = header_etag_parser("If-Match")
+        with self.assertRaises(ValidationError) as exc_info:
+            parser(request)
+        self.assertEqual(exc_info.exception.detail[0].code, "invalid_header")

--- a/tests/drf/test_fencing.py
+++ b/tests/drf/test_fencing.py
@@ -2,11 +2,14 @@ import datetime
 import operator
 from unittest import TestCase
 
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from django.utils.http import http_date
 
 from bananas.drf.errors import BadRequest
 from bananas.drf.fencing import (
     Fence,
+    allow_if_unmodified_since,
     as_set,
     header_date_parser,
     header_etag_parser,
@@ -115,6 +118,13 @@ class TestParseDateModified(TestCase):
             date_modified = None
 
         self.assertIsNone(parse_date_modified(A()))
+
+
+class TestAllowIfUnmodifiedSince(TestCase):
+    @override_settings(USE_TZ=False)
+    def test_raises_improperly_configured_for_naive_django_config(self):
+        with self.assertRaises(ImproperlyConfigured):
+            allow_if_unmodified_since()
 
 
 class TestHeaderEtagParser(TestCase):

--- a/tests/drf/test_fencing.py
+++ b/tests/drf/test_fencing.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from django.utils.http import http_date
+from drf_yasg import openapi
 
 from bananas.drf.errors import BadRequest
 from bananas.drf.fencing import (
@@ -21,6 +22,12 @@ from .request import FakeRequest
 
 
 class TestFence(TestCase):
+    openapi_parameter = openapi.Parameter(
+        in_=openapi.IN_HEADER,
+        name="foo",
+        type=openapi.TYPE_STRING,
+    )
+
     def test_check_propagates_error_from_get_token(self):
         error = RuntimeError()
 
@@ -30,7 +37,12 @@ class TestFence(TestCase):
         def get_version(_instance):
             return "a"
 
-        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+        fence = Fence(
+            get_token=get_token,
+            compare=operator.eq,
+            get_version=get_version,
+            openapi_parameter=self.openapi_parameter,
+        )
 
         with self.assertRaises(RuntimeError) as exc_info:
             fence.check(FakeRequest.fake(), "a")
@@ -46,7 +58,12 @@ class TestFence(TestCase):
         def get_version(_instance):
             raise error
 
-        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+        fence = Fence(
+            get_token=get_token,
+            compare=operator.eq,
+            get_version=get_version,
+            openapi_parameter=self.openapi_parameter,
+        )
 
         with self.assertRaises(RuntimeError) as exc_info:
             fence.check(FakeRequest.fake(), "a")
@@ -60,7 +77,12 @@ class TestFence(TestCase):
         def get_version(_instance):
             return "a"
 
-        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+        fence = Fence(
+            get_token=get_token,
+            compare=operator.eq,
+            get_version=get_version,
+            openapi_parameter=self.openapi_parameter,
+        )
 
         self.assertIs(fence.check(FakeRequest.fake(), "a"), True)
 
@@ -71,7 +93,12 @@ class TestFence(TestCase):
         def get_version(_instance):
             return "b"
 
-        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+        fence = Fence(
+            get_token=get_token,
+            compare=operator.eq,
+            get_version=get_version,
+            openapi_parameter=self.openapi_parameter,
+        )
 
         self.assertIs(fence.check(FakeRequest.fake(), "a"), False)
 
@@ -82,7 +109,12 @@ class TestFence(TestCase):
         def get_version(_instance):
             return None
 
-        fence = Fence(get_token=get_token, compare=operator.eq, get_version=get_version)
+        fence = Fence(
+            get_token=get_token,
+            compare=operator.eq,
+            get_version=get_version,
+            openapi_parameter=self.openapi_parameter,
+        )
 
         self.assertIs(fence.check(FakeRequest.fake(), "a"), True)
 

--- a/tests/drf/test_utils.py
+++ b/tests/drf/test_utils.py
@@ -1,0 +1,29 @@
+import datetime
+from unittest import TestCase
+
+from django.utils.http import http_date
+
+from bananas.drf.utils import parse_header_datetime
+
+from .request import FakeRequest
+
+
+class TestParseHeaderDatetime(TestCase):
+    def test_raises_value_error_for_missing_header(self):
+        request = FakeRequest.fake()
+        with self.assertRaisesRegex(
+            ValueError, r"^Header missing in request: missing_header$"
+        ):
+            parse_header_datetime(request, "missing_header")
+
+    def test_raises_value_error_for_invalid_header_value(self):
+        request = FakeRequest.fake(headers={"invalid": "not a date"})
+        with self.assertRaisesRegex(
+            ValueError, r"^Malformed header in request: invalid$"
+        ):
+            parse_header_datetime(request, "invalid")
+
+    def test_can_parse_datetime(self):
+        dt = datetime.datetime(2021, 1, 14, 17, 30, 1, tzinfo=datetime.timezone.utc)
+        request = FakeRequest.fake(headers={"valid": http_date(dt.timestamp())})
+        self.assertEqual(dt, parse_header_datetime(request, "valid"))

--- a/tests/drf/test_utils.py
+++ b/tests/drf/test_utils.py
@@ -3,27 +3,48 @@ from unittest import TestCase
 
 from django.utils.http import http_date
 
-from bananas.drf.utils import parse_header_datetime
+from bananas.drf.utils import (
+    InvalidHeader,
+    MissingHeader,
+    parse_header_datetime,
+    parse_header_etags,
+)
 
 from .request import FakeRequest
 
 
 class TestParseHeaderDatetime(TestCase):
-    def test_raises_value_error_for_missing_header(self):
+    def test_raises_missing_header(self):
         request = FakeRequest.fake()
-        with self.assertRaisesRegex(
-            ValueError, r"^Header missing in request: missing_header$"
-        ):
-            parse_header_datetime(request, "missing_header")
+        with self.assertRaises(MissingHeader):
+            parse_header_datetime(request, "missing")
 
-    def test_raises_value_error_for_invalid_header_value(self):
+    def test_raises_invalid_header(self):
         request = FakeRequest.fake(headers={"invalid": "not a date"})
-        with self.assertRaisesRegex(
-            ValueError, r"^Malformed header in request: invalid$"
-        ):
+        with self.assertRaises(InvalidHeader):
             parse_header_datetime(request, "invalid")
 
     def test_can_parse_datetime(self):
         dt = datetime.datetime(2021, 1, 14, 17, 30, 1, tzinfo=datetime.timezone.utc)
         request = FakeRequest.fake(headers={"valid": http_date(dt.timestamp())})
         self.assertEqual(dt, parse_header_datetime(request, "valid"))
+
+
+class TestParseHeaderEtags(TestCase):
+    def test_raises_missing_header(self):
+        request = FakeRequest.fake()
+        with self.assertRaises(MissingHeader):
+            parse_header_etags(request, "missing")
+
+    def test_raises_invalid_header(self):
+        request = FakeRequest.fake(headers={"invalid": ""})
+        with self.assertRaises(InvalidHeader):
+            parse_header_etags(request, "invalid")
+
+    def test_can_parse_single_etag(self):
+        request = FakeRequest.fake(headers={"tag": '"value"'})
+        self.assertSetEqual(parse_header_etags(request, "tag"), {"value"})
+
+    def test_can_parse_many_tags(self):
+        request = FakeRequest.fake(headers={"tag": '"a", "b"'})
+        self.assertSetEqual(parse_header_etags(request, "tag"), {"a", "b"})

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,9 +2,7 @@ from django.db import models
 from django.db.models import Model
 from django.db.models.manager import Manager
 
-from bananas.models import (
-    TimeStampedModel, URLSecretField, SecretField, UUIDModel
-)
+from bananas.models import SecretField, TimeStampedModel, URLSecretField, UUIDModel
 from bananas.query import ExtendedQuerySet, ModelDictManagerMixin
 
 
@@ -23,7 +21,11 @@ class Parent(TimeStampedModel):
 
     @property
     def attribute_error(self):
-        return getattr(object(), 'missing_attribute')
+        return getattr(object(), "missing_attribute")
+
+    @property
+    def version(self) -> str:
+        return str(self.pk) + ":" + str(self.date_modified)
 
 
 class Child(TimeStampedModel):
@@ -34,14 +36,13 @@ class Child(TimeStampedModel):
 
 class Node(TimeStampedModel):
     name = models.CharField(max_length=255)
-    parent = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
+    parent = models.ForeignKey("self", null=True, on_delete=models.CASCADE)
     objects = Manager.from_queryset(ExtendedQuerySet)()
 
 
 class TestUUIDModel(UUIDModel):
     text = models.CharField(max_length=255)
-    parent = models.ForeignKey('TestUUIDModel', null=True,
-                               on_delete=models.CASCADE)
+    parent = models.ForeignKey("TestUUIDModel", null=True, on_delete=models.CASCADE)
 
 
 class SecretModel(models.Model):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -50,3 +50,6 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSION": 1.0,
     "ALLOWED_VERSIONS": [1.0],
 }
+
+# TODO: Document requirement
+USE_TZ = True

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,5 +51,4 @@ REST_FRAMEWORK = {
     "ALLOWED_VERSIONS": [1.0],
 }
 
-# TODO: Document requirement
 USE_TZ = True

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,11 +1,9 @@
 from contextlib import contextmanager
 from functools import wraps
-from unittest import skipIf
 
-import django
 from django.contrib.auth.models import AnonymousUser, Group, Permission, User
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 from bananas import admin

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,3 @@
-import django
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -9,7 +8,7 @@ class CommandTests(TestCase):
     def test_show_urls(self):
         urls = show_urls.collect_urls()
 
-        admin_api_url_count = 44
+        admin_api_url_count = 50
         self.assertEqual(len(urls), admin_api_url_count)
 
         class FakeSys:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,7 +8,7 @@ class CommandTests(TestCase):
     def test_show_urls(self):
         urls = show_urls.collect_urls()
 
-        admin_api_url_count = 50
+        admin_api_url_count = 48
         self.assertEqual(len(urls), admin_api_url_count)
 
         class FakeSys:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,7 +8,7 @@ class CommandTests(TestCase):
     def test_show_urls(self):
         urls = show_urls.collect_urls()
 
-        admin_api_url_count = 48
+        admin_api_url_count = 50
         self.assertEqual(len(urls), admin_api_url_count)
 
         class FakeSys:

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,8 +2,10 @@ from django.conf.urls import include, re_path
 
 from bananas import admin
 from bananas.admin import api
-from .admin_api import FooAPI, HamAPI
+
 from . import separate_api
+from .admin_api import FooAPI, HamAPI
+from .drf import fenced_api
 
 urlpatterns = [re_path(r"^admin/", admin.site.urls)]
 
@@ -14,4 +16,5 @@ api.register(HamAPI)
 urlpatterns += [
     re_path(r"^api/bananas", include("bananas.admin.api.urls")),
     re_path(r"^api/separate", include(separate_api)),
+    re_path(r"^api/", include(fenced_api)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -55,3 +55,4 @@ deps =
     black
     isort<5
     django-stubs
+    djangorestframework-stubs


### PR DESCRIPTION
### Todo

- [x] Write docs
- [x] Document `USE_TZ` requirement
- [x] Guard against using `USE_TZ = False`
- [x] Coverage
- [x] OpenAPI schema

Using the allow_if_unmodified_since from this patch requires USE_TZ = True. In my opinion that's best practice anyway and reasonable requirement, let me know if you think we should support USE_TZ = False. We should document the requirement and look into ways of making friendly and early error messages.