### PR TITLE
Fix incorrect MRO introduced in previous fix

### DIFF
--- a/bananas/drf/fencing.py
+++ b/bananas/drf/fencing.py
@@ -10,7 +10,6 @@ from typing import (
     List,
     NoReturn,
     Optional,
-    Protocol,
     TypeVar,
     cast,
 )
@@ -25,7 +24,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer, ModelSerializer
 from rest_framework.viewsets import GenericViewSet
-from typing_extensions import Final, final
+from typing_extensions import Final, Protocol, final
 
 from bananas.admin.api.schemas.yasg import BananasSwaggerSchema
 from bananas.models import TimeStampedModel

--- a/tests/drf/fenced_api.py
+++ b/tests/drf/fenced_api.py
@@ -22,9 +22,7 @@ class SimpleSerializer(ModelSerializer):
 class AllowIfUnmodifiedSinceAPI(FencedUpdateModelMixin, GenericViewSet):
     fence = allow_if_unmodified_since()
     serializer_class = SimpleSerializer
-
-    def get_queryset(self):
-        return Parent.objects.all()
+    queryset = Parent.objects.all()
 
 
 class AllowIfMatchAPI(FencedUpdateModelMixin, GenericViewSet):


### PR DESCRIPTION
#62 introduced another bug breaking subclasses that uses `queryset = ...` and don't override `get_queryset()`.