### PR TITLE
Make BananasAPI compatible with APIView

### DIFF
--- a/bananas/admin/api/mixins.py
+++ b/bananas/admin/api/mixins.py
@@ -1,7 +1,16 @@
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAdminUser
+from typing import Optional, Sequence, Type, Union
+
+from drf_yasg.inspectors.view import SwaggerAutoSchema
+from rest_framework.authentication import BaseAuthentication, SessionAuthentication
+from rest_framework.permissions import (
+    BasePermission,
+    IsAdminUser,
+    OperandHolder,
+    SingleOperandHolder,
+)
 from rest_framework.reverse import reverse
 from rest_framework.utils import formatting
+from rest_framework.versioning import BaseVersioning
 
 from bananas.models import ModelDict
 
@@ -10,13 +19,17 @@ from .versioning import BananasVersioning
 
 UNDEFINED = object()
 
+_PermissionClass = Union[Type[BasePermission], OperandHolder, SingleOperandHolder]
+
 
 class BananasAPI:
 
-    versioning_class = BananasVersioning
-    authentication_classes = (SessionAuthentication,)
-    permission_classes = (IsAdminUser,)
-    swagger_schema = BananasSchema  # for DRF: schema = BananasSchema()
+    versioning_class: Optional[Type[BaseVersioning]] = BananasVersioning
+    authentication_classes: Sequence[Type[BaseAuthentication]] = (
+        SessionAuthentication,
+    )
+    permission_classes: Sequence[_PermissionClass] = (IsAdminUser,)
+    swagger_schema: type[SwaggerAutoSchema] = BananasSchema
 
     @classmethod
     def get_admin_meta(cls):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,9 @@
+from rest_framework import mixins
+from bananas.admin.api.views import BananasAdminAPI
+
+class Subclass(
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    mixins.UpdateModelMixin,
+    BananasAdminAPI,
+): ...

--- a/tests/test_admin.yaml
+++ b/tests/test_admin.yaml
@@ -1,0 +1,23 @@
+# Test that types on BananasAPI are compatible with those of APIView.
+- case: can_subclass_admin_and_views
+  main: |
+    from rest_framework import mixins
+    from bananas.admin.api.views import BananasAdminAPI
+
+    class Subclass(
+      mixins.RetrieveModelMixin,
+      mixins.ListModelMixin,
+      mixins.UpdateModelMixin,
+      BananasAdminAPI,
+    ): ...
+
+    reveal_type(Subclass.versioning_class)
+    reveal_type(Subclass.renderer_classes)
+  out: |
+    main:11: note: Revealed type is 'Union[Type[rest_framework.versioning.BaseVersioning], None]'
+    main:12: note: Revealed type is 'typing.Sequence[Type[rest_framework.renderers.BaseRenderer]]'
+  mypy_config: |
+    [mypy-django.*]
+    ignore_errors = True
+    [mypy-rest_framework.*]
+    ignore_errors = True


### PR DESCRIPTION
I discovered that subclassing `BananasAdminAPI` gives type errors because there are currently incompatibilities between `BananasAPI` (which we haven't added types to yet, and ignore in setup.cfg) and `APIView`. I think though that this means we need to either add types to the entire package, have all users add the same ignore as we're currently doing in setup.cfg, or disable exposing types for now (e.g. removing py.typed). No great options, though would of course be preferable to move forward and type everything IMO.

There's also a bug in https://github.com/typeddjango/djangorestframework-stubs/pull/146 that this breaks on.