### PR TITLE
Env util helper `get_path`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,4 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
       - uses: pre-commit/action@v2.0.3

--- a/src/bananas/environment.py
+++ b/src/bananas/environment.py
@@ -272,7 +272,7 @@ class EnvironWrapper:
     def get_bool(self, key: str, default: None = None) -> Optional[bool]:
         ...
 
-    def get_bool(self, key: str, default: object = None) -> object:
+    def get_bool(self, key: str, default: Optional[Path] = None) -> Optional[Path]:
         return self.parse(parse_bool, key, default=default)
 
     @overload

--- a/src/bananas/environment.py
+++ b/src/bananas/environment.py
@@ -272,7 +272,7 @@ class EnvironWrapper:
     def get_bool(self, key: str, default: None = None) -> Optional[bool]:
         ...
 
-    def get_bool(self, key: str, default: Optional[Path] = None) -> Optional[Path]:
+    def get_bool(self, key: str, default: object = None) -> object:
         return self.parse(parse_bool, key, default=default)
 
     @overload
@@ -283,7 +283,7 @@ class EnvironWrapper:
     def get_path(self, key: str, default: None = None) -> Optional[Path]:
         ...
 
-    def get_path(self, key: str, default: object = None) -> object:
+    def get_path(self, key: str, default: Optional[Path] = None) -> Optional[Path]:
         return self.parse(parse_path, key, default=default)
 
     @overload

--- a/src/bananas/environment.py
+++ b/src/bananas/environment.py
@@ -1,6 +1,7 @@
 import logging
 from functools import partial
 from os import environ
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -57,6 +58,16 @@ def parse_str(value: str) -> str:
     :return: str: Cleaned str.
     """
     return value.strip()
+
+
+def parse_path(value: str) -> Path:
+    """
+    Parse string to pathlib.Path.
+
+    :param str value: String value to parse as path
+    :return Path:
+    """
+    return Path(value)
 
 
 def parse_bool(value: str) -> bool:
@@ -263,6 +274,17 @@ class EnvironWrapper:
 
     def get_bool(self, key: str, default: object = None) -> object:
         return self.parse(parse_bool, key, default=default)
+
+    @overload
+    def get_path(self, key: str, default: Path) -> Path:
+        ...
+
+    @overload
+    def get_path(self, key: str, default: None = None) -> Optional[Path]:
+        ...
+
+    def get_path(self, key: str, default: object = None) -> object:
+        return self.parse(parse_path, key, default=default)
 
     @overload
     def get_int(self, key: str, default: U) -> Union[int, U]:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 from os import environ
+from pathlib import Path
 
 from django.conf import global_settings
 from django.core.exceptions import ValidationError
@@ -300,6 +301,9 @@ class EnvTest(TestCase):
         self.assertSetEqual(env.get_set("foobar"), {"a", "b", "c"})
         self.assertEqual(env.get("foobar"), "a, b, c")
         self.assertEqual(env["foobar"], "a, b, c")
+
+        environ["foobar"] = "/tmp"
+        self.assertEqual(env.get_path("foobar"), Path("/tmp"))
 
 
 class SettingsTest(TestCase):


### PR DESCRIPTION
Based on a suggestion from @flaeppe, this adds a method to the environment parsing helper that allows parsing strings as a `pathlib.Path`.
