### PR TITLE
Add type hints to admin and query modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Upgrade packaging tools
         run: python -m pip install --upgrade pip setuptools virtualenv
       - name: Install dependencies
@@ -70,4 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
       - uses: pre-commit/action@v2.0.3

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ exclude runtests.py tox.ini *.yml *.yaml Makefile Dockerfile .editorconfig
 recursive-include src/bananas/templates *
 recursive-include src/bananas/static *
 recursive-include src *.py
+recursive-include src py.typed
 recursive-exclude example *
 recursive-exclude scripts *
 recursive-exclude tests *

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,7 @@ test_all:
 
 .PHONY: test-types      # runs pytest-mypy-plugins to test exported types
 test-types:
-	# Hack to make type-tests work until we add py.typed to the published package.
-	touch $$(python -c 'import bananas; print(bananas.__path__[0] + "/py.typed")')
 	pytest --mypy-ini-file=setup.cfg tests/*.yaml
-	rm $$(python -c 'import bananas; print(bananas.__path__[0] + "/py.typed")')
 
 .PHONY: coverage		# combines coverage and reports it
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ help:
 test:
 	python -X dev -Wd -m coverage run runtests.py $(test)
 
-.PHONY: test_all		# runs tests using detox, combines coverage and reports it
+.PHONY: test_all		# runs tests using tox -p, combines coverage and reports it
 test_all:
-	detox
+	tox -p
 	make coverage
 
 .PHONY: test-types      # runs pytest-mypy-plugins to test exported types

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ drf =
     djangorestframework>=3.10
     drf-yasg>=1.20.0
 test =
-    detox
+    tox
     coverage
 dev =
     mypy
@@ -118,12 +118,6 @@ plugins =
 
 [mypy.plugins.django-stubs]
 django_settings_module = tests.settings
-
-[mypy-bananas.admin.*]
-ignore_errors = True
-
-[mypy-bananas.query.*]
-ignore_errors = True
 
 [mypy-tests.*]
 disallow_untyped_defs = False

--- a/src/bananas/admin/api/i18n.py
+++ b/src/bananas/admin/api/i18n.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from django.views.i18n import JavaScriptCatalog
 
 
@@ -5,5 +7,5 @@ class RawTranslationCatalog(JavaScriptCatalog):
 
     domain = "django"
 
-    def render_to_response(self, context, **response_kwargs):
+    def render_to_response(self, context: Dict[str, Any], **response_kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]
         return context

--- a/src/bananas/admin/api/mixins.py
+++ b/src/bananas/admin/api/mixins.py
@@ -23,6 +23,7 @@ UNDEFINED = object()
 class BananasAPI:
 
     # TODO: DRF stubs should change versioning type to `Type[BaseVersioning]`
+    #       See: https://github.com/typeddjango/djangorestframework-stubs/pull/146
     versioning_class: Optional[str] = BananasVersioning  # type: ignore[assignment]
     authentication_classes: Sequence[Type[BaseAuthentication]] = (
         SessionAuthentication,

--- a/src/bananas/admin/api/mixins.py
+++ b/src/bananas/admin/api/mixins.py
@@ -1,37 +1,52 @@
-from rest_framework.authentication import SessionAuthentication
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Type, TypeVar, cast
+
+from django.db.models import Model
+from rest_framework.authentication import BaseAuthentication, SessionAuthentication
 from rest_framework.permissions import IsAdminUser
 from rest_framework.reverse import reverse
 from rest_framework.utils import formatting
+from rest_framework.views import APIView
+from rest_framework.viewsets import GenericViewSet, ViewSetMixin
 
 from bananas.models import ModelDict
 
 from .schemas import BananasSchema
 from .versioning import BananasVersioning
 
+if TYPE_CHECKING:
+    from rest_framework.permissions import _PermissionClass
+    from rest_framework.serializers import BaseSerializer
+
 UNDEFINED = object()
 
 
 class BananasAPI:
 
-    versioning_class = BananasVersioning
-    authentication_classes = (SessionAuthentication,)
-    permission_classes = (IsAdminUser,)
+    # TODO: DRF stubs should change versioning type to `Type[BaseVersioning]`
+    versioning_class: Optional[str] = BananasVersioning  # type: ignore[assignment]
+    authentication_classes: Sequence[Type[BaseAuthentication]] = (
+        SessionAuthentication,
+    )
+    permission_classes: Sequence["_PermissionClass"] = (IsAdminUser,)
     swagger_schema = BananasSchema  # for DRF: schema = BananasSchema()
 
+    _admin_meta: ModelDict
+    basename: str
+
     @classmethod
-    def get_admin_meta(cls):
-        meta = getattr(cls, "_admin_meta", None)
+    def get_admin_meta(cls) -> ModelDict:
+        meta: Optional[ModelDict] = getattr(cls, "_admin_meta", None)
 
         if meta is None:
             # TODO: Get proper app_label, not only root package
             app_label, __, __ = cls.__module__.lower().partition(".")
-            name = cls.get_view_name(cls)
+            name = cls.get_view_name(cls)  # type: ignore[arg-type]
 
             basename = getattr(cls, "basename", None)
             if basename is None:
                 if type(name).__name__ == "__proxy__":
                     # name is lazy, probably gettext, extract basename from class name
-                    basename = cls.get_view_name(cls, respect_name=False)
+                    basename = cls.get_view_name(cls, respect_name=False)  # type: ignore[arg-type]
                 else:
                     basename = name
                 basename = basename.replace(" ", "_").lower()
@@ -51,7 +66,7 @@ class BananasAPI:
                     {
                         key: getattr(admin, key)
                         for key in filter(
-                            lambda key: key in meta, admin.__dict__.keys()
+                            lambda key: key in meta, admin.__dict__.keys()  # type: ignore[operator]
                         )
                     }
                 )
@@ -62,32 +77,34 @@ class BananasAPI:
 
         return meta
 
-    def reverse_action(self, url_name, *args, **kwargs):
+    def reverse_action(self, url_name: str, *args: Any, **kwargs: Any) -> str:
         """
         Extended DRF with fallback to requested namespace if request.version is missing
         """
-        if self.request and not self.request.version:
+        request = cast(APIView, self).request
+        if request and not request.version:
             return reverse(self.get_url_name(url_name), *args, **kwargs)
 
-        return super().reverse_action(url_name, *args, **kwargs)
+        return cast(ViewSetMixin, super()).reverse_action(url_name, *args, **kwargs)
 
-    def get_url_name(self, action_url_name="list"):
+    def get_url_name(self, action_url_name: str = "list") -> str:
         """
         Get full namespaced url name to use for reverse()
         """
         url_name = f"{self.basename}-{action_url_name}"
 
-        namespace = self.request.resolver_match.namespace
+        namespace = cast(APIView, self).request.resolver_match.namespace
         if namespace:
             url_name = f"{namespace}:{url_name}"
 
         return url_name
 
-    def get_view_name(self, respect_name=True):
+    def get_view_name(self, respect_name: bool = True) -> str:
         """
         Get or generate human readable view name.
         Extended version from DRF to support usage from both class and instance.
         """
+        view: Type
         if isinstance(self, type):
             view = self
         else:
@@ -95,28 +112,31 @@ class BananasAPI:
 
         # Name may be set by some Views, such as a ViewSet.
         if respect_name:
-            name = getattr(view, "name", None)
+            name: Optional[str] = getattr(view, "name", None)
             if name is not None:
                 return name
 
         name = view.__name__
-        for suffix in ("ViewSet", "View", "API", "Admin"):
-            name = formatting.remove_trailing_string(name, suffix)
+        for view_suffix in ("ViewSet", "View", "API", "Admin"):
+            name = formatting.remove_trailing_string(name, view_suffix)
         name = formatting.camelcase_to_spaces(name)
 
         # Suffix may be set by some Views, such as a ViewSet.
-        suffix = getattr(view, "suffix", None)
+        suffix: Optional[str] = getattr(view, "suffix", None)
         if suffix:
             name += " " + suffix
 
         return name
 
 
-class SchemaSerializerMixin:
-    def get_serializer_class(self, status_code: int = None):
-        serializer_class = super().get_serializer_class()
+_MT_co = TypeVar("_MT_co", bound=Model, covariant=True)
 
-        action = getattr(self, self.action, None)
+
+class SchemaSerializerMixin:
+    def get_serializer_class(self) -> Type["BaseSerializer[_MT_co]"]:
+        serializer_class = cast(GenericViewSet, super()).get_serializer_class()
+
+        action = getattr(self, cast(GenericViewSet, self).action, None)
         schema = getattr(action, "_swagger_auto_schema", None)
         if schema:
             responses = schema.get("responses")

--- a/src/bananas/admin/api/permissions.py
+++ b/src/bananas/admin/api/permissions.py
@@ -1,4 +1,6 @@
 from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 
 class IsAnonymous(BasePermission):
@@ -6,5 +8,5 @@ class IsAnonymous(BasePermission):
     Allows access only to non-authenticated users.
     """
 
-    def has_permission(self, request, view):
+    def has_permission(self, request: Request, view: APIView) -> bool:
         return not request.user or request.user.is_anonymous

--- a/src/bananas/admin/api/router.py
+++ b/src/bananas/admin/api/router.py
@@ -1,15 +1,25 @@
+from typing import TYPE_CHECKING, Type, TypeVar, cast
+
+from rest_framework.viewsets import ViewSetMixin
+
 from .schemas import BananasRouter
+
+if TYPE_CHECKING:
+    from .mixins import BananasAPI
 
 __all__ = ["register"]
 
 
-def register(view):  # Type[BananasAPI]
+T = TypeVar("T", bound=ViewSetMixin)
+
+
+def register(view: Type[T]) -> None:
     """
     Register the API view class in the bananas router.
 
     :param BananasAPI view:
     """
-    meta = view.get_admin_meta()
+    meta = cast("BananasAPI", view).get_admin_meta()
     prefix = meta.basename.replace(".", "/")
     router.register(prefix, view, meta.basename)
 

--- a/src/bananas/admin/api/schemas/base.py
+++ b/src/bananas/admin/api/schemas/base.py
@@ -1,6 +1,14 @@
-class BananasBaseRouter:
-    def get_default_basename(self, viewset):
-        return viewset.get_admin_meta().basename
+from typing import TYPE_CHECKING, Any, Type, cast
 
-    def get_schema_view(self):
+from rest_framework.viewsets import ViewSetMixin
+
+if TYPE_CHECKING:
+    from ..mixins import BananasAPI
+
+
+class BananasBaseRouter:
+    def get_default_basename(self, viewset: Type[ViewSetMixin]) -> str:
+        return cast(Type["BananasAPI"], viewset).get_admin_meta().basename  # type: ignore[no-any-return]
+
+    def get_schema_view(self) -> Any:
         raise NotImplementedError

--- a/src/bananas/admin/api/schemas/decorators.py
+++ b/src/bananas/admin/api/schemas/decorators.py
@@ -1,7 +1,16 @@
-def tags(include=None, exclude=None):
-    def decorator(view):
-        view.include_tags = include
-        view.exclude_tags = exclude
+from typing import Callable, Optional, Sequence
+
+from django.http.response import HttpResponseBase
+
+View = Callable[..., HttpResponseBase]
+
+
+def tags(
+    include: Optional[Sequence[str]] = None, exclude: Optional[Sequence[str]] = None
+) -> Callable[[View], View]:
+    def decorator(view: View) -> View:
+        view.include_tags = include  # type: ignore[attr-defined]
+        view.exclude_tags = exclude  # type: ignore[attr-defined]
         return view
 
     return decorator

--- a/src/bananas/admin/api/versioning.py
+++ b/src/bananas/admin/api/versioning.py
@@ -1,3 +1,7 @@
+from types import ModuleType
+from typing import Dict, Sequence
+
+from rest_framework.request import Request
 from rest_framework.versioning import NamespaceVersioning
 
 from . import v1_0
@@ -7,11 +11,15 @@ __versions__ = [v1_0]
 
 class BananasVersioning(NamespaceVersioning):
 
-    default_version = v1_0.__version__
-    allowed_versions = {version.__version__ for version in __versions__}
-    version_map = {version.__version__: version for version in __versions__}
+    default_version: str = v1_0.__version__
+    allowed_versions: Sequence[str] = tuple(
+        version.__version__ for version in __versions__
+    )
+    version_map: Dict[str, ModuleType] = {
+        version.__version__: version for version in __versions__
+    }
 
-    def get_versioned_viewname(self, viewname, request):
+    def get_versioned_viewname(self, viewname: str, request: Request) -> str:
         """
         Prefix viewname with full namespace bananas:vX.Y:
         """

--- a/src/bananas/admin/api/views.py
+++ b/src/bananas/admin/api/views.py
@@ -3,10 +3,12 @@ from django.contrib.auth import (
     logout as auth_logout,
     update_session_auth_hash,
 )
+from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status, viewsets
 from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from .i18n import RawTranslationCatalog
@@ -37,7 +39,7 @@ class LoginAPI(BananasAdminAPI):
         verbose_name_plural = None
 
     @schema(responses={200: UserSerializer})
-    def create(self, request):
+    def create(self, request: Request) -> Response:
         """
         Log in django staff user
         """
@@ -66,7 +68,7 @@ class LogoutAPI(BananasAPI, viewsets.ViewSet):
         verbose_name_plural = None
 
     @schema(responses={204: ""})
-    def create(self, request):
+    def create(self, request: Request) -> Response:
         """
         Log out django staff user
         """
@@ -82,7 +84,7 @@ class MeAPI(BananasAdminAPI):
         exclude_tags = ["navigation"]
 
     @schema(responses={200: UserSerializer})
-    def list(self, request):
+    def list(self, request: Request) -> Response:
         """
         Retrieve logged in user info
         """
@@ -100,12 +102,13 @@ class ChangePasswordAPI(BananasAdminAPI):
         verbose_name_plural = None
 
     @schema(responses={204: ""})
-    def create(self, request):
+    def create(self, request: Request) -> Response:
         """
         Change password for logged in django staff user
         """
         # TODO: Decorate api with sensitive post parameters as Django admin do?
 
+        assert isinstance(request.user, AbstractBaseUser)
         password_form = PasswordChangeForm(request.user, data=request.data)
 
         if not password_form.is_valid():
@@ -127,7 +130,7 @@ class TranslationAPI(BananasAdminAPI):
         exclude_tags = ["navigation"]
 
     @schema(responses={200: ""})
-    def list(self, request):
+    def list(self, request: Request) -> Response:
         """
         Retrieve the translation catalog.
         """

--- a/src/bananas/models.py
+++ b/src/bananas/models.py
@@ -202,7 +202,7 @@ class SecretField(models.CharField):
 
         field_length = self.get_field_length(self.num_bytes)
 
-        defaults: Mapping[str, object] = {
+        defaults: Mapping[str, Any] = {
             "max_length": field_length,
             **kwargs,
             **(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 
 from bananas import environment
 from bananas.environment import env
-from bananas.query import ModelDict
+from bananas.models import ModelDict
 
 from .models import (
     Child,


### PR DESCRIPTION
Continuation of #70 

There's probably quite a bit of refinement that can be done here, but at least it should make tests green without ignoring errors from `query` and `admin` modules.