### PR TITLE
Bump various dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
           show_line: true
           show_branch: true
           show_missing: true
+          link_missing_lines: true
+          link_missing_lines_source_dir: "src"
 
   type-check:
     name: Run type checks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,10 @@ jobs:
           ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
           TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
       - name: Generate coverage file
-        if: matrix.python-version == "3.10"
+        if: matrix.python-version == '3.10'
         run: "TOXENV=coverage python -m tox"
       - name: Report coverage
-        if: matrix.python-version == "3.10" && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
+        if: matrix.python-version == '3.10' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
         uses: 5monkeys/cobertura-action@master
         with:
           path: coverage.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,10 @@ jobs:
           ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
           TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
       - name: Generate coverage file
-        if: matrix.python-version == 3.10
+        if: matrix.python-version == "3.10"
         run: "TOXENV=coverage python -m tox"
       - name: Report coverage
-        if: matrix.python-version == 3.10 && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
+        if: matrix.python-version == "3.10" && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
         uses: 5monkeys/cobertura-action@master
         with:
           path: coverage.xml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Upgrade packaging tools
         run: python -m pip install --upgrade pip setuptools virtualenv
       - name: Install dependencies
@@ -70,5 +70,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -35,10 +34,10 @@ jobs:
           ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
           TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
       - name: Generate coverage file
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == 3.10
         run: "TOXENV=coverage python -m tox"
       - name: Report coverage
-        if: matrix.python-version == 3.9 && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
+        if: matrix.python-version == 3.10 && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize')
         uses: 5monkeys/cobertura-action@master
         with:
           path: coverage.xml
@@ -56,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: 3.10
       - name: Upgrade packaging tools
         run: python -m pip install --upgrade pip setuptools virtualenv
       - name: Install dependencies
@@ -71,5 +70,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: 3.10
       - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,8 @@ repos:
     rev: "0.47"
     hooks:
       - id: check-manifest
+        # See https://github.com/mgedmin/check-manifest/issues/141
+        args: ["--no-build-isolation"]
 
 exclude: |
   (?x)(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_language_version:
-  python: python3.9
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -11,11 +11,11 @@ repos:
       - id: debug-statements
       - id: detect-private-key
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py37-plus
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
@@ -25,18 +25,18 @@ repos:
           - --remove-all-unused-imports
           - --ignore-init-module-imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.1.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.11.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==21.9b0]
+        additional_dependencies: [black==22.1.0]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
@@ -46,7 +46,7 @@ repos:
           - flake8-comprehensions
           - flake8-tidy-imports
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.5.1
+    rev: 0.11.0
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/mgedmin/check-manifest

--- a/src/bananas/admin/api/urls.py
+++ b/src/bananas/admin/api/urls.py
@@ -4,7 +4,7 @@ from .versioning import __versions__
 
 apipatterns = [
     re_path(
-        fr"^{version.__version__}/",
+        rf"^{version.__version__}/",
         include(
             (f"{version.__name__}.urls", "bananas"),
             namespace=version.__version__,

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,10 @@
 # Currently `pip install tox==3.0.0rc2`
 
 [tox]
-envlist = py36-django{ 22, 30, 32 },
-          py37-django{ 22, 30, 31, 32 },
-          py38-django{ 22, 30, 31, 32, 40 },
-          py39-django{ 22, 30, 31, 32, 40 }
-          py310-django{ 32, 40 }
+envlist = py37-django{ 22, 32 },
+          py38-django{ 22, 32, 40 },
+          py39-django{ 22, 32, 40 }
+          py310-django{    32, 40 }
 isolated_build = true
 
 
@@ -27,14 +26,9 @@ extras =
     test
     drf
 deps = django22: Django>=2.2,<2.3
-       django30: Django<3.1
-       django31: Django<3.2
-       django31: Django<4.0
-       # TODO: Change to non-pre version when 4.0 is released.
-       django40: Django==4.0a1
+       django32: Django<4.0
+       django40: Django<4.1
        django22: djangorestframework>=3.10.0,<3.11
-       django30: djangorestframework>=3.11.0,<3.12
-       django31: djangorestframework>=3.12.0
        django32: djangorestframework>=3.12.0
        # TODO: Change to proper version when a version with this commit is available.
        django40: https://github.com/encode/django-rest-framework/archive/c62e3ca764d90e7b8402cc4022cffad2a07fa5be.zip
@@ -46,7 +40,7 @@ deps = django22: Django>=2.2,<2.3
 [testenv:coverage]
 skip_install = true
 passenv = COVERAGE_FILE
-basepython = python3.9
+basepython = python3.10
 commands =
     make coverage-xml
 deps =
@@ -54,7 +48,7 @@ deps =
 
 
 [testenv:type-check]
-basepython = python3.9
+basepython = python3.10
 skip_install = true
 commands =
     make type-check test-types

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 [tox]
 envlist = py37-django{ 22, 32 },
           py38-django{ 22, 32, 40 },
-          py39-django{ 22, 32, 40 }
+          py39-django{ 22, 32, 40 },
           py310-django{    32, 40 }
 isolated_build = true
 


### PR DESCRIPTION
- Drop end-of-lifed Django versions 3.0 and 3.1.
- Drop end-of-lifed Python 3.6 from test matrix.
- Bump pre-commit dependencies and set pyupgrade to --py37-plus.