### PR TITLE
Introduce reusable workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,10 +67,6 @@ jobs:
 
   lint:
     name: Checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - uses: pre-commit/action@v2.0.3
+    uses: less-action/reusables/.github/workflows/pre-commit.yaml@v1
+    with:
+      python-version: "3.10"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,11 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    uses: less-action/reusables/.github/workflows/python-publish.yaml@v1
+    secrets:
+      pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,8 @@ with the ``drf`` extra to keep those in sync:
 
 Currently tested only for
 
--   Django 2.2 under Python 3.6-3.9
--   Django 3.0 under Python 3.6-3.9
--   Django 3.1 under Python 3.6-3.9
--   Django 3.2 under Python 3.6-3.9
+-   Django 2.2 under Python 3.7-3.9
+-   Django 3.2 under Python 3.7-3.9
 -   Django 4.0 under Python 3.8-3.10
 
 Pull requests welcome!


### PR DESCRIPTION
- Workflow for building and publishing package to PyPI when Github release is created.
- Reusable workflow for running pre-commit, because the action is deprecated.
- Update supported versions in README.

From discussion here: https://github.com/5monkeys/django-bananas/pull/78#issuecomment-1038928850

This requires generating an access token on PyPI scoped for django-bananas and creating the secret `PYPI_API_TOKEN` with that value.